### PR TITLE
Remove duplicate Bootstrap includes and fix phone link

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,6 @@
             <!-- CSS Files -->
         <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
         <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css" rel="stylesheet">
-        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha3/dist/css/bootstrap.min.css" rel="stylesheet">
         <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
         <link href="https://fonts.googleapis.com/css2?family=Alex+Brush&family=Pacifico&family=Ruge+Boogie&family=Tangerine:wght@400;700&display=swap" rel="stylesheet">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.1.1/animate.min.css">
@@ -320,7 +319,7 @@
         <div class="sticky-social-bar">
             <ul class="list-unstyled">
                 <li>
-                    <a href="tel:123-456-7890" class="social-icon" title="Call Us">
+                    <a href="tel:573-803-2797" class="social-icon" title="Call Us">
                         <i class="bi bi-telephone-fill"></i>
                     </a>
                 </li>
@@ -350,7 +349,6 @@
 
          <!-- Bootstrap JS -->
          <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
-        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha3/dist/js/bootstrap.bundle.min.js"></script>
         <!-- AOS JS -->
         <script src="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.js"></script>
         <script src="design.js"></script>


### PR DESCRIPTION
## Summary
- remove outdated Bootstrap 5.3.0-alpha3 CSS/JS references
- update sticky social bar to use salon's real phone number

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a3f383ecf88326a9231783dc62f1f8