### PR TITLE
Use only Inter and Tangerine fonts

### DIFF
--- a/cape.html
+++ b/cape.html
@@ -8,8 +8,7 @@
             <!-- CSS Files -->
         <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
         <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css" rel="stylesheet">
-        <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-        <link href="https://fonts.googleapis.com/css2?family=Alex+Brush&family=Pacifico&family=Ruge+Boogie&family=Tangerine:wght@400;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Tangerine:wght@400;700&display=swap" rel="stylesheet">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.1.1/animate.min.css">
         <link href="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.css" rel="stylesheet">
         <link href="design.css" rel="stylesheet">

--- a/design.css
+++ b/design.css
@@ -2,12 +2,21 @@ html {
     scroll-behavior: smooth;
 }
 
-p{
-font-style: italic;
+:root {
+    --bs-font-sans-serif: "Inter", sans-serif;
+    --bs-body-font-family: "Inter", sans-serif;
 }
 
-h1{
-    font-family: "Tangerine", sans-serif !important;
+body {
+    font-family: var(--bs-body-font-family);
+}
+
+p{
+    font-style: italic;
+}
+
+h1, h2, h3, h4, h5, h6 {
+    font-family: "Tangerine", cursive !important;
 }
 
 .navbar {
@@ -68,33 +77,33 @@ h1{
     box-shadow: 0 8px 16px rgba(0, 0, 0, 0.2);
 }
 .sectionHeadingMain{
-    font-family: "Pacifico", serif;
+    font-family: "Tangerine", cursive;
     color: rgb(168, 136, 199);
     font-size: 48px !important;
     font-weight: 100 !important;
 }
 .service-card-heading {
-    font-family: "Tangerine", sans-serif !important;
+    font-family: "Tangerine", cursive !important;
     color: rgb(119, 82, 148) !important;
     font-weight: 700 !important;
     font-size: 36px;
 }
 .listOtherServices{
-    font-family: "Tangerine", sans-serif !important;
+    font-family: "Tangerine", cursive !important;
     color: rgb(119, 82, 148) !important;
     font-weight: 700 !important;
     font-size: 32px;
 }
 .headingCallToAction{
-    font-family: "Tangerine", sans-serif !important;
+    font-family: "Tangerine", cursive !important;
     color: rgb(119, 82, 148) !important;
     font-weight: 700 !important;
     font-size: 48px;
 }
 .manicureList{
-    font-family: "Lora", serif;
+    font-family: "Inter", sans-serif;
     color: rgb(68, 68, 68);
-    line-height: 1.6; 
+    line-height: 1.6;
 }
 
 .btn-fancy-outline {

--- a/locations.html
+++ b/locations.html
@@ -5,8 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>POSH Nail Locations</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=Alex+Brush&family=Pacifico&family=Ruge+Boogie&family=Tangerine:wght@400;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Tangerine:wght@400;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.1.1/animate.min.css">
     <link href="design.css" rel="stylesheet">
 </head>


### PR DESCRIPTION
## Summary
- import just Inter (body) and Tangerine (decorative) fonts in `cape.html` and `locations.html`
- standardize `design.css` to use Inter for body content and Tangerine for headings

## Testing
- `npx --yes -p jsdom node <<'NODE'
const fs=require('fs');
const {JSDOM}=require('jsdom');
function check(page){const html=fs.readFileSync(page,'utf8');const css=fs.readFileSync('design.css','utf8');const dom=new JSDOM(html,{pretendToBeVisual:true});const document=dom.window.document;const styleEl=document.createElement('style');styleEl.textContent=css;document.head.appendChild(styleEl);const win=dom.window;const heading=document.querySelector('h1')||document.querySelector('h2');const headingFont=heading?win.getComputedStyle(heading).fontFamily:'none';const button=document.querySelector('a.btn')||document.querySelector('button');const buttonFont=button?win.getComputedStyle(button).fontFamily:'none';const listItem=document.querySelector('li');const listFont=listItem?win.getComputedStyle(listItem).fontFamily:'none';console.log(page,{headingFont,buttonFont,listFont});}
check('cape.html');
check('locations.html');
NODE` *(fails: npm error code E403)*

------
https://chatgpt.com/codex/tasks/task_b_68a4202cb8a4832690e036bb27446aed