### PR TITLE
Improve mobile layout and social bar behavior

### DIFF
--- a/design.css
+++ b/design.css
@@ -287,3 +287,38 @@ footer {
     }
 }
 
+@media (max-width: 576px) {
+    .hero-section {
+        height: auto;
+    }
+
+    .hero-section .container {
+        padding-top: 60px !important;
+    }
+
+    .hero-section h1 {
+        font-size: 2rem;
+    }
+
+    .btn-fancy,
+    .btn-fancy-outline {
+        padding: 10px 20px;
+        font-size: 0.9rem;
+    }
+
+    #otherServices,
+    #manicureSection,
+    #callToAction {
+        padding: 30px 0;
+    }
+
+    .sectionHeadingMain,
+    .headingCallToAction {
+        font-size: 36px !important;
+    }
+
+    .sticky-social-bar {
+        display: none;
+    }
+}
+


### PR DESCRIPTION
## Summary
- Add <576px breakpoint adjusting hero heading, button sizes, and section spacing
- Hide sticky social bar on narrow screens to prevent overlap

## Testing
- `npx prettier -c "**/*.{html,css,js}"` *(warned about code style issues in existing files)*

------
https://chatgpt.com/codex/tasks/task_b_68a4219edb6883269a0e86c1c816d40a